### PR TITLE
Fixed some typos

### DIFF
--- a/chipset/chip.html
+++ b/chipset/chip.html
@@ -1,4 +1,4 @@
-<html lang="es">
+<html lang="en">
   <head>
     <link rel="stylesheet" type="text/css" href="../documentation.css" />
     <link rel="icon" href="https://raw.githubusercontent.com/redtoast/NeetComputers/refs/heads/live-20.1/assets_dev/logo.png">
@@ -30,7 +30,7 @@
       <p>Gets the current time in <a href="https://en.wikipedia.org/wiki/Unix_time" target="_blank">Unix time</a></p>
 
       <h3>getTimeAlive()</h3>
-      <p>Gets the amount of milliseconds sense the computer has started ticking</p>
+      <p>Gets the amount of milliseconds since the computer has started ticking</p>
 
       <h3>getUUID()</h3>
       <p>Returns the UUID of this computer as a string, this uuid is persistent</p>
@@ -57,7 +57,7 @@
       <p>Finds the maximum amount of cores this computer can run</p>
 
       <h3>createCore(script)</h3>
-      <p>Opens a new core running the provided script and returns the cores UUID, if the core cap has not been exited, throws if it has</p>
+      <p>Opens a new core running the provided script and returns the cores UUID, if the core cap has not been exceeded, throws if it has</p>
 
       <h3>killCore(UUID)</h3>
       <p>Terminates the core that <i>UUID</i> belongs too, and returns if this operation was successful</p>

--- a/chipset/event.html
+++ b/chipset/event.html
@@ -1,4 +1,4 @@
-<html lang="es">
+<html lang="en">
 <head>
     <link rel="stylesheet" type="text/css" href="../documentation.css" />
     <link rel="icon" href="https://raw.githubusercontent.com/redtoast/NeetComputers/refs/heads/live-20.1/assets_dev/logo.png">
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Oswald" />
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
-    <title>Chip API</title>
+    <title>Event API</title>
 </head>
 <body>
 <a href="../categories/chipset.html" id="headerlink"><h1>Chipset / Event API</h1></a>
@@ -17,7 +17,7 @@
     <p id="getEventqueue()">Returns a List of all events in the queue, the queue files with events as they happen, each event is represented with a list containing the event name and then custom data</p>
 
     <h3>clearEventQueue()</h3>
-    <p>Manually clears <a href="#getEventqueue()" class="silent">the event queue</a>, make sure to call this function because the queue is not cleared automatically except to make room if it reloads a size 0f 100</p>
+    <p>Manually clears <a href="#getEventqueue()" class="silent">the event queue</a>, make sure to call this function because the queue is not cleared automatically except to make room if it reaches a size of 100</p>
 
     <h3>queueEvent(eventName, arguments...)</h3>
     <p>Manually inject an event into the queue next tick</p>
@@ -26,7 +26,7 @@
     <p>Before each tick, every instance of the <i>eventName</i> will be passed as a list into the <i>function</i>, the function will be called with the event name and parameters provided individually</p>
 
     <h3>registerEvent(function)</h3>
-    <p>Before each tick, every instance of any event will be passed as a list into the <i>function</i>, unlike <a href="#registerEvent">registerEvent</a> the event is passed as a list. also keep in mind the event queue is capped at 100 events and will start forgetting old events if that cap is exited</p>
+    <p>Before each tick, every instance of any event will be passed as a list into the <i>function</i>, unlike <a href="#registerEvent">registerEvent</a> the event is passed as a list. Also keep in mind the event queue is capped at 100 events and will start forgetting old events if that cap is reached</p>
 </div>
 </body>
 </html>

--- a/chipset/peripherals.html
+++ b/chipset/peripherals.html
@@ -1,4 +1,4 @@
-<html lang="es">
+<html lang="en">
 <head>
     <link rel="stylesheet" type="text/css" href="../documentation.css" />
     <link rel="icon" href="https://raw.githubusercontent.com/redtoast/NeetComputers/refs/heads/live-20.1/assets_dev/logo.png">
@@ -26,13 +26,13 @@
     <p>Gets the type of <i>peripheral</i> as a string</p>
 
     <h3>retrieve(UUID)</h3>
-    <p>Retrieves the peripheral with the accosted <i>UUID</i>, or null if no such peripheral exists</p>
+    <p>Retrieves the peripheral with the <i>UUID</i>, or null if no such peripheral exists</p>
 
     <h3>locate(type)</h3>
     <p>Returns all peripherals with this type in the form of a <a href="../concepts/tuple.html">tuple</a></p>
 
     <h3>getAll()</h3>
-    <p>Returns a list of every peripheral register</p>
+    <p>Returns a list of every peripheral registered</p>
 </div>
 </body>
 </html>

--- a/chipset/screen.html
+++ b/chipset/screen.html
@@ -1,4 +1,4 @@
-<html lang="es">
+<html lang="en">
   <head>
     <link rel="stylesheet" type="text/css" href="../documentation.css" />
     <link rel="icon" href="https://raw.githubusercontent.com/redtoast/NeetComputers/refs/heads/live-20.1/assets_dev/logo.png">
@@ -33,7 +33,7 @@
       <p>Sets the transparency of drawn graphics, ranging 1 - 256 with 1 being fully invisible. note that unlike RGB graphics you can not manually override the alpha value for each function call.</p>
 
       <h3>setColor(R, G, B, A)</h3>
-      <p>Combined functionality of setColor(R, G, B) with setColor(Alpha), pretty strait forward.</p>
+      <p>Combined functionality of setColor(R, G, B) with setColor(Alpha), pretty straight forward.</p>
     </div>
 
     <hr>


### PR DESCRIPTION
There where some typos in documentation pages inside `chipset` (did not check other files). I fixed hopefully most of these typos, I did not look at `chipset/periperhals`.

`chipset/screen.html` contained some other typos which I didn’t fix, more info in commit https://github.com/redtoast/NeetDocumentation/commit/de66ad2e23f70143da418b371748256abd00a1a8.